### PR TITLE
Fixbug incorrect cpu usage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -44,6 +44,7 @@ public class LinuxInfoUtils {
     private static final String CGROUPS_CPU_USAGE_PATH = "/sys/fs/cgroup/cpu/cpuacct.usage";
     private static final String CGROUPS_CPU_LIMIT_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
     private static final String CGROUPS_CPU_LIMIT_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+    private static final String CGROUPS_CPU_USAGE_PER_CPU_PATH = "/sys/fs/cgroup/cpu/cpuacct.usage_percpu";
     // proc states
     private static final String PROC_STAT_PATH = "/proc/stat";
     private static final String NIC_PATH = "/sys/class/net/";
@@ -85,6 +86,8 @@ public class LinuxInfoUtils {
                 if (quota > 0) {
                     return 100.0 * quota / period;
                 }
+                int cpuCount = readTrimStringFromFile(Paths.get(CGROUPS_CPU_USAGE_PER_CPU_PATH)).split(" ").length;
+                return cpuCount * 100;
             } catch (IOException e) {
                 log.warn("[LinuxInfo] Failed to read CPU quotas from cgroups", e);
                 // Fallback to availableProcessors

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -78,15 +78,15 @@ public class LinuxInfoUtils {
      * @return Total cpu count
      */
     public static int getTotalCpuCount() throws IOException {
-        int totalCpuCount=0;
+        int totalCpuCount = 0;
         String[] ranges = readTrimStringFromFile(Paths.get(CGROUPS_CPU_CPUSET_CPUS)).split(",");
         for (String range : ranges) {
             if (!range.contains("-")) {
                 totalCpuCount++;
             } else {
                 int dashIndex = range.indexOf('-');
-                int left = Integer.valueOf(range.substring(0, dashIndex));
-                int right = Integer.valueOf(range.substring(dashIndex + 1));
+                int left = Integer.parseInt(range.substring(0, dashIndex));
+                int right = Integer.parseInt(range.substring(dashIndex + 1));
                 totalCpuCount += right - left + 1;
             }
         }
@@ -106,7 +106,10 @@ public class LinuxInfoUtils {
                 if (quota > 0) {
                     return 100.0 * quota / period;
                 }
-                return getTotalCpuCount() * 100;
+                int totalCpuCount = getTotalCpuCount();
+                if (totalCpuCount > 0) {
+                    return 100 * totalCpuCount;
+                }
             } catch (IOException e) {
                 log.warn("[LinuxInfo] Failed to read CPU quotas from cgroups", e);
                 // Fallback to availableProcessors
@@ -252,11 +255,11 @@ public class LinuxInfoUtils {
         return Paths.get(String.format(template, nic));
     }
 
-    private static String readTrimStringFromFile(Path path) throws IOException {
+    public static String readTrimStringFromFile(Path path) throws IOException {
         return new String(Files.readAllBytes(path), StandardCharsets.UTF_8).trim();
     }
 
-    private static long readLongFromFile(Path path) throws IOException {
+    public static long readLongFromFile(Path path) throws IOException {
         return Long.parseLong(readTrimStringFromFile(path));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -77,23 +77,18 @@ public class LinuxInfoUtils {
      *  Get total cpu count.
      * @return Total cpu count
      */
-    public static int getTotalCpuCount() {
+    public static int getTotalCpuCount() throws IOException {
         int totalCpuCount=0;
-        try {
-            String[] ranges = readTrimStringFromFile(Paths.get(CGROUPS_CPU_CPUSET_CPUS)).split(",");
-            for (String range : ranges) {
-                if (!range.contains("-")) {
-                    totalCpuCount++;
-                } else {
-                    int dashIndex = range.indexOf('-');
-                    int left = Integer.valueOf(range.substring(0, dashIndex));
-                    int right = Integer.valueOf(range.substring(dashIndex + 1));
-                    totalCpuCount += right - left + 1;
-                }
+        String[] ranges = readTrimStringFromFile(Paths.get(CGROUPS_CPU_CPUSET_CPUS)).split(",");
+        for (String range : ranges) {
+            if (!range.contains("-")) {
+                totalCpuCount++;
+            } else {
+                int dashIndex = range.indexOf('-');
+                int left = Integer.valueOf(range.substring(0, dashIndex));
+                int right = Integer.valueOf(range.substring(dashIndex + 1));
+                totalCpuCount += right - left + 1;
             }
-        } catch (IOException e) {
-            log.warn("[LinuxInfo] Failed to read CPU counts from cgroups", e);
-            // Fallback to availableProcessors
         }
         return totalCpuCount;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtilsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtilsTest.java
@@ -1,0 +1,31 @@
+package org.apache.pulsar.broker.loadbalance;
+
+import static org.testng.Assert.assertEquals;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class LinuxInfoUtilsTest {
+
+    /**
+     * simulate reading contents in /sys/fs/cgroup/cpuset/cpuset.cpus to get the number of Cpus.
+     */
+    @Test
+    public void testGetTotalCpuCount() {
+        int totalCpuCount=0;
+        String CPU_CPUSET_CPUS = "0-2,16,20-30";
+        String[] ranges = CPU_CPUSET_CPUS.split(",");
+        for (String range : ranges) {
+            if (!range.contains("-")) {
+                totalCpuCount++;
+            } else {
+                int dashIndex = range.indexOf('-');
+                int left = Integer.valueOf(range.substring(0, dashIndex));
+                int right = Integer.valueOf(range.substring(dashIndex + 1));
+                totalCpuCount += right - left + 1;
+            }
+        }
+        assertEquals(totalCpuCount, 15);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtilsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtilsTest.java
@@ -1,7 +1,11 @@
 package org.apache.pulsar.broker.loadbalance;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertEquals;
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.mockito.MockedStatic;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -9,23 +13,20 @@ import org.testng.annotations.Test;
 public class LinuxInfoUtilsTest {
 
     /**
-     * simulate reading contents in /sys/fs/cgroup/cpuset/cpuset.cpus to get the number of Cpus.
+     * simulate reading contents in /sys/fs/cgroup/cpuset/cpuset.cpus to get the number of Cpus
+     * and return the limit of cpu.
      */
     @Test
-    public void testGetTotalCpuCount() {
-        int totalCpuCount=0;
-        String CPU_CPUSET_CPUS = "0-2,16,20-30";
-        String[] ranges = CPU_CPUSET_CPUS.split(",");
-        for (String range : ranges) {
-            if (!range.contains("-")) {
-                totalCpuCount++;
-            } else {
-                int dashIndex = range.indexOf('-');
-                int left = Integer.valueOf(range.substring(0, dashIndex));
-                int right = Integer.valueOf(range.substring(dashIndex + 1));
-                totalCpuCount += right - left + 1;
-            }
+    public void testGetTotalCpuCountAndLimit() throws IOException {
+        try (MockedStatic<LinuxInfoUtils> linuxInfoUtils = mockStatic(LinuxInfoUtils.class)) {
+            linuxInfoUtils.when(() -> LinuxInfoUtils.readTrimStringFromFile(any())).thenReturn("0-2,16,20-30");
+            linuxInfoUtils.when(() -> LinuxInfoUtils.getTotalCpuCount()).thenCallRealMethod();
+            assertEquals(LinuxInfoUtils.getTotalCpuCount(), 15);
+
+            //set quota to -1
+            linuxInfoUtils.when(() -> LinuxInfoUtils.readLongFromFile(any())).thenReturn(-1L);
+            linuxInfoUtils.when(() -> LinuxInfoUtils.getTotalCpuLimit(true)).thenCallRealMethod();
+            assertEquals(LinuxInfoUtils.getTotalCpuLimit(true), 1500);
         }
-        assertEquals(totalCpuCount, 15);
     }
 }


### PR DESCRIPTION

<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/17815

Incorrect CPU usage collected by pulsar

### Motivation

cpu usage reported by pulsar is greater than 100%,needed to be fixed.

### Modifications

org.apache.pulsar.broker.loadbalance.LinuxInfoUtils#getTotalCpuLimit
if CGROUP is enabled and quota is -1, we utilize the content of /sys/fs/cgroup/cpuset/cpuset.cpus to get the correct number of CPUs in the system.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->
 `doc-not-needed` 
(Please explain why)

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
